### PR TITLE
Fixed build.gradle android plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@
 
 buildscript {
     repositories {
+    	google()
         jcenter()
     }
     dependencies {


### PR DESCRIPTION
Android plugin 3.0.1 requires the google() repository in buildscript.